### PR TITLE
Create default structure for the organization

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help maintainers and contributors understand what needs to be fixed
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+> :warning:
+> Hello, and thank you for your contributions!<br>
+> Please review the following checklist before creating a new pull request:
+>
+> - Review and contribute to existing pull requests and open issues to avoid redundant efforts.
+> - Read [the contribution guidelines](CONTRIBUTING.md).
+> - Assign reviewers.
+> - If applicable, include a reference to related issues.
+>
+> :warning: Delete this block before creating the pull request.
+
+**Describe the changes proposed**
+A clear and concise description of the changes included in this pull request.
+
+**Screenshots / Videos**
+If useful, include any screeshots or screencasts to better explain the change.
+
+**Additional context**
+Add any other context about the change here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,63 @@
+# Google Open Source Community Guidelines
+
+At Google, we recognize and celebrate the creativity and collaboration of open
+source contributors and the diversity of skills, experiences, cultures, and
+opinions they bring to the projects and communities they participate in.
+
+Every one of Google's open source projects and communities are inclusive
+environments, based on treating all individuals respectfully, regardless of
+gender identity and expression, sexual orientation, disabilities,
+neurodiversity, physical appearance, body size, ethnicity, nationality, race,
+age, religion, or similar personal characteristic.
+
+We value diverse opinions, but we value respectful behavior more.
+
+Respectful behavior includes:
+
+* Being considerate, kind, constructive, and helpful.
+* Not engaging in demeaning, discriminatory, harassing, hateful, sexualized, or
+  physically threatening behavior, speech, and imagery.
+* Not engaging in unwanted physical contact.
+
+Some Google open source projects [may adopt][] an explicit project code of
+conduct, which may have additional detailed expectations for participants. Most
+of those projects will use our [modified Contributor Covenant][].
+
+[may adopt]: https://opensource.google/docs/releasing/preparing/#conduct
+[modified Contributor Covenant]: https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/
+
+## Resolve peacefully
+
+We do not believe that all conflict is necessarily bad; healthy debate and
+disagreement often yields positive results. However, it is never okay to be
+disrespectful.
+
+If you see someone behaving disrespectfully, you are encouraged to address the
+behavior directly with those involved. Many issues can be resolved quickly and
+easily, and this gives people more control over the outcome of their dispute.
+If you are unable to resolve the matter for any reason, or if the behavior is
+threatening or harassing, report it. We are dedicated to providing an
+environment where participants feel welcome and safe.
+
+## Reporting problems
+
+Some Google open source projects may adopt a project-specific code of conduct.
+In those cases, a Google employee will be identified as the Project Steward,
+who will receive and handle reports of code of conduct violations. In the event
+that a project hasn’t identified a Project Steward, you can report problems by
+emailing opensource@google.com.
+
+We will investigate every complaint, but you may not receive a direct response.
+We will use our discretion in determining when and how to follow up on reported
+incidents, which may range from not taking action to permanent expulsion from
+the project and project-sponsored spaces. We will notify the accused of the
+report and provide them an opportunity to discuss it before any action is
+taken. The identity of the reporter will be omitted from the details of the
+report supplied to the accused. In potentially harmful situations, such as
+ongoing harassment or threats to anyone's safety, we may take action without
+notice.
+
+*This document was adapted from the [IndieWeb Code of Conduct][] and can also
+be found at <https://opensource.google/conduct/>.*
+
+[IndieWeb Code of Conduct]: https://indieweb.org/code-of-conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# How to Contribute
+
+We would love to accept your patches and contributions to this project.
+
+## Before you begin
+
+### Sign our Contributor License Agreement
+
+Contributions to this project must be accompanied by a
+[Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
+You (or your employer) retain the copyright to your contribution; this simply
+gives us permission to use and redistribute your contributions as part of the
+project.
+
+If you or your current employer have already signed the Google CLA (even if it
+was for a different project), you probably don't need to do it again.
+
+Visit <https://cla.developers.google.com/> to see your current agreements or to
+sign a new one.
+
+### Review our Community Guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+
+## Contribution process
+
+### Code Reviews
+
+All submissions, including submissions by project members, require review. We
+use [GitHub pull requests](https://docs.github.com/articles/about-pull-requests)
+for this purpose.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+Please do not open GitHub issues or pull requests - this makes the problem immediately visible to everyone, including malicious actors.   
+
+To report a security issue, please use [https://g.co/vulnz](https://g.co/vulnz).
+We use g.co/vulnz for our intake, and do coordination and disclosure here on
+GitHub (including using GitHub Security Advisory). The Google Security Team will
+respond within 5 working days of your report on g.co/vulnz.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,17 @@
+# Welcome to the Google Wallet organization
+
+The Google Wallet API enables fast, secure access to passes that power everyday essentials.
+
+## Get started with Google Wallet
+To learn more about Google Wallet, see <https://developers.google.com/wallet>
+Use our tutorials to get started quickly!
+
+## Repositories
+
+The Google Wallet organization features various repositories. Here are some relevant ones:
+
+<!-- alphabetical -->
+* [android-codelab](https://github.com/google-wallet/android-codelab): A sample application using the Google Wallet API for Android.
+* [pass-converter](https://github.com/google-wallet/pass-converter): A tool to convert passes across formats for different wallet apps.
+* [rest-samples](https://github.com/google-wallet/rest-samples): Samples for the Google Wallet REST APIs.
+* [web-codelab](https://github.com/google-wallet/web-codelab): A sample application using the Google Wallet API for Web.


### PR DESCRIPTION
This includes:
- A readme for the organization that shows in the landing page of the org (see [example](https://github.com/google-pay)) @yanaga to update the contents
- Default definitions for (can be overriden per repo):
  - License
  - Contributing guidelines
  - Issue and PR templates
  - Code of conduct
  - Security policy

Read more about [default community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)